### PR TITLE
Fix resolved path on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ function resolve(name, parentFile) {
     name = path.resolve(path.dirname(parentFile), name);
   }
   var resolved = loader.normalizeSync(name).replace("file://", "");
+  if (process.platform === 'win32') {
+    resolved = resolved.replace(/^\//, '');
+  }
   if (resolved) {
     try {
       if (fs.statSync(resolved).isDirectory()) {


### PR DESCRIPTION
No idea if tern-jspm was tested on Windows at all, but it did not work on my machine. Some debugging has shown that normalized `resolved` path looks like `/C:/dev/project/src/file.js` instead of `C:/dev/project/src/file.js`. My JSPM is 0.17.0-beta.32, in case that's important.